### PR TITLE
Upgrade to Stream Engine 3.0.4.6031

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,12 @@
 // use std::env;
 
 fn main() {
+    #[cfg(target_os="linux")]
+    println!("cargo:rustc-link-lib=tobii_stream_engine");
+
+    #[cfg(target_os="macos")]
     println!("cargo:rustc-link-search=framework=/Library/Application Support/Tobii/");
+
     // cc::Build::new().file("dummy.c").warnings(false).flag("-Wl,-rpath,/Library/Application Support/Tobii/").compile("dummyc");
     // println!("cargo:root={}", env::var("OUT_DIR").unwrap());
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -97,5 +97,5 @@ pub unsafe fn reconnect(device: *mut Device) -> Status {
 
 pub unsafe fn wait_for_device_callbacks(device: *mut Device) -> Status {
     let ptr_ptr_dev: *const *mut Device = (&device) as *const *mut Device;
-    tobii_wait_for_callbacks(ptr::null_mut(), 1, ptr_ptr_dev)
+    tobii_wait_for_callbacks(1, ptr_ptr_dev)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,9 +278,7 @@ extern "C" {
                                device: *mut *mut Device)
                                -> Status;
     pub fn tobii_device_destroy(device: *mut Device) -> Status;
-    // TODO add support for engine type
-    pub fn tobii_wait_for_callbacks(engine: *mut ::std::os::raw::c_void,
-                                    device_count: ::std::os::raw::c_int,
+    pub fn tobii_wait_for_callbacks(device_count: ::std::os::raw::c_int,
                                     devices: *const *mut Device)
                                     -> Status;
     pub fn tobii_device_process_callbacks(device: *mut Device) -> Status;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,9 @@ pub type EyePositionNormalizedFn = :: std :: option :: Option < unsafe extern "C
 
 
 
-#[link(name = "StreamEngineClientKit", kind = "framework")]
+// TODO: The following line is needed for linking on macOS, but breaks building on
+// Linux. How to make it conditional?
+//#[link(name = "StreamEngineClientKit", kind = "framework")]
 extern "C" {
     pub fn tobii_error_message(error: Status) -> *const ::std::os::raw::c_char;
     pub fn tobii_get_api_version(version: *mut Version) -> Status;


### PR DESCRIPTION
In `README.md` you state that you were using an alpha version of the API. In the meantime, Tobii have released [Stream Engine API](https://developer.tobii.com/consumer-eye-trackers/stream-engine/getting-started/) for Linux which can be [downloaded from them with an account](https://developer.tobii.com/wp-login.php?redirect_to=%2Fconsumer-eye-trackers%2Fstream-engine%2Fgetting-started%2F). I just had to make one small tweak (see the change in `src/lib.rs`) to be able to "recycle" your bindings.

This change is breaking with respect to the API you were wrapping, but maybe that can be resolved with some clever use of `cfg`. I am new to Rust and could not get the following to work:

```rust
    // TODO add support for engine type
    #[cfg(target_os = "macos")]
    pub fn tobii_wait_for_callbacks(engine: *mut ::std::os::raw::c_void,
                                    device_count: ::std::os::raw::c_int,
                                    devices: *const *mut Device)
                                    -> Status;
    #[cfg(target_os = "linux")]
    pub fn tobii_wait_for_callbacks(device_count: ::std::os::raw::c_int,
                                    devices: *const *mut Device)
                                    -> Status;
```

```rust
pub unsafe fn wait_for_device_callbacks(device: *mut Device) -> Status {
    let ptr_ptr_dev: *const *mut Device = (&device) as *const *mut Device;
    #[cfg(target_os = "macos")]
    {
        tobii_wait_for_callbacks(ptr::null_mut(), 1, ptr_ptr_dev)
    }
    #[cfg(target_os = "linux")]
    {
        tobii_wait_for_callbacks(1, ptr_ptr_dev)
    }
    #[cfg(not(tobii_wait_for_callbacks))]
    {
        panic!("tobii_wait_for_device_callbacks not available")
    }
}
```

```
error[E0308]: mismatched types
   --> src/helpers.rs:_:9
    |
 _  |         tobii_wait_for_callbacks(1, ptr_ptr_dev)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- help: try adding a semicolon: `;`
    |         |
    |         expected (), found u32
    |
    = note: expected type `()`
               found type `u32`